### PR TITLE
Readme: suggest using `.phpcs.xml.dist` rather than `phpcs.xml` file for repo rulesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To override the default PHP version check, set the `PHPCS_PHP_VERSION` environme
 
 ### IDE Integration
 
-Some IDE integrations of PHPCS fail to register the `10up-Default` ruleset. In order to rectify this, place `phpcs.xml` at your project root:
+Some IDE integrations of PHPCS fail to register the `10up-Default` ruleset. In order to rectify this, place `.phpcs.xml.dist` at your project root:
 
 ```xml
 <?xml version="1.0"?>


### PR DESCRIPTION
Using a `.dist` file for a repo ruleset allows for individual developers to overrule the ruleset with a custom version (without the `.dist` file extension).
This makes testing of new additions/changes to the ruleset easier.
The master ruleset can be imported into a custom ruleset by using `<rule ref="./.phpcs.xml.dist"/>`.

Since PHPCS 3.1.0, it is also possible to use dot-prefixed files for the PHPCS config, allowing these files to be sorted with other configuration related files.

The loading order of the ruleset files in PHPCS, as of version 3.1.1, is:
1. `.phpcs.xml`
2. `phpcs.xml`
3. `.phpcs.xml.dist`
4. `phpcs.xml.dist`

### References:
* https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.1.0
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.1.1 (change in the file loading order)