### PR TITLE
Allow shorthand array syntax

### DIFF
--- a/10up-Default/ruleset.xml
+++ b/10up-Default/ruleset.xml
@@ -57,6 +57,9 @@
 		<!-- Comment punctuation doesn't matter -->
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
 		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop"/>
+		
+		<!-- Allow shorthand array syntax -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
 	</rule>
 
 	<!-- Sets the minimum supported WP version to 4.7, which is over a year old. -->


### PR DESCRIPTION
WPCS requires arrays to be declared using long array syntax in WordPress Core:

https://github.com/WordPress/WordPress-Coding-Standards/pull/1770
https://make.wordpress.org/core/2019/07/12/php-coding-standards-changes/

This update allows shorthand syntax in projects using the 10up PHPCS Configuration.
