### PR TITLE
Bump PHP test version to 7.4

### DIFF
--- a/10up-Default/ruleset.xml
+++ b/10up-Default/ruleset.xml
@@ -85,5 +85,5 @@
 	<rule ref="PHPCompatibilityWP" />
 
 	<!-- PHP version check. -->
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="7.4-"/>
 </ruleset>


### PR DESCRIPTION
### Description of the Change

The current sniffer is throwing errors when using PHP 7.2+ syntax such as `?string` with parameter and return type hinting. We should bump the test version to `7.4` to stay in line with [PHP LTS supported versions](https://www.php.net/supported-versions.php) and to keep our CI command clean and simple to understand. The alternative is to change the PHP at run time like this: `phpcs . --runtime-set testVersion 7.4-`.

Closes #27 

### Changelog Entry

> Changed - Bump PHP test version to 7.4

### Credits

@claytoncollie 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
