### PR TITLE
Ignore the `dist` directory

### DIFF
--- a/10up-Default/ruleset.xml
+++ b/10up-Default/ruleset.xml
@@ -3,6 +3,7 @@
 	<description>A base ruleset that all other 10up rulesets should extend.</description>
 
 	<exclude-pattern>*/phpunit.xml*</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
 	<exclude-pattern>*/languages/*</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
 


### PR DESCRIPTION
### Description of the Change

This PR adds an exclusion for the entire `dist` directory. This is a dynamically built directory when using tools like 10up-toolkit and should not be subject to coding standards since it is not version controlled. If you do not ignore this directory, the CI pipeline could break when deploying code to the server.

Closes #30 

### Changelog Entry

> Added - Exclude all files in the `dist` directory

### Credits

@claytoncollie 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
