### PR TITLE
Add "static analysis" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "10up/phpcs-composer",
     "type": "phpcodesniffer-standard",
+    "keywords" : [ "phpcs", "static analysis" ],
     "version": "dev-master",
     "license": "MIT",
     "require": {


### PR DESCRIPTION

### Description of the Change

As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.

The "phpcs" keyword is to match other coding-standards packages.

### How to test the Change

Apply the patch locally, and with Composer 2.4.0-RC1 or later, try to install with just `composer require`.

### Changelog Entry

Add "static analysis" Composer keyword.


### Credits

Props @GaryJones


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
