### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/10up-Default/ruleset.xml
+++ b/10up-Default/ruleset.xml
@@ -85,5 +85,5 @@
 	<rule ref="PHPCompatibilityWP" />
 
 	<!-- PHP version check. -->
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="8.1-"/>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "phpcompatibility/phpcompatibility-wp": "^2",
-        "squizlabs/php_codesniffer" : "^3.4.0",
+        "squizlabs/php_codesniffer" : "3.7.1",
         "wp-coding-standards/wpcs": "*"
     },
     "prefer-stable" : true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d34786e15e9782c187e8804f279a71cf",
+    "content-hash": "3e59f0da31e468070ad991260a1bac46",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -234,16 +234,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -281,7 +281,12 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -337,5 +342,6 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
### Description of the Change

The current sniffer is throwing errors when using PHP 8.1+ syntax such as `?string` with parameter and return type hinting. We should bump the test version to `8.1` to stay in line with [PHP LTS supported versions](https://www.php.net/supported-versions.php) and to keep our CI command clean and simple to understand. The alternative is to change the PHP at run time like this: `phpcs . --runtime-set testVersion 8.1-`.

This PR also updates the squizlabs package to the latest version to be compatible with PHP 8.1

Closes #27 
Closes #34 

### Changelog Entry

> Changed - Bump PHP test version to 8.1
> Change - Bump squizlabs/php_codesniffer to 3.7.1

### Credits

@claytoncollie @iansvo @johnwatkins0 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.

### Upgrade Path

For projects using this repository with a composer.json file, you should be referencing the `dev-master` branch like so, `"10up/phpcs-composer": "dev-master"` which means to get the latest version, you need to delete your `composer.lock` file and then re-install your dependencies with `composer install`

Once you have the latest version of this repository pulled in, make sure to remove the `testVersion` flag in your terminal command. Meaning that if you have `phpcs . --runtime-set testVersion 7.4-`, the command can now be simplified to `phpcs .`. You should now be linting against PHP version 8.1 and below.
