### PR TITLE
Enable Nonce Verification Sniff.

### DIFF
--- a/10up-Default/ruleset.xml
+++ b/10up-Default/ruleset.xml
@@ -63,9 +63,6 @@
 
 		<!-- Allow WP global modification -->
 		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited"/>
-
-		<!-- This nonce sniff almost never works right -->
-		<exclude name="WordPress.Security.NonceVerification.Missing"/>
 	</rule>
 
 	<!-- Sets the minimum supported WP version to 4.7, which is over a year old. -->

--- a/10up-Default/ruleset.xml
+++ b/10up-Default/ruleset.xml
@@ -84,6 +84,24 @@
 	<!-- Make sure that the proper escaping functions are being used -->
 	<rule ref="WordPressVIPMinimum.Security.ProperEscapingFunction"/>
 
+
+	<rule ref="WP.Security.ValidatedSanitizedInput">
+		<properties>
+			<property name="customUnslashingSanitizingFunctions" type="array">
+				<!--
+					Allow checking nonces without sanitization.
+					
+					WordPress nonces do not include any characters requiring
+					slashes so can be considered unslashed. The verification
+					is a character by character comparison to a fixed value
+					so sanitization is not required as only a valid nonce
+					string should be allowed to pass.
+				-->
+				<element value="wp_verify_nonce" />
+			</property>
+		</properties>
+	</rule>
+
 	<!-- Loads the PHP Compatibility ruleset. -->
 	<rule ref="PHPCompatibilityWP" />
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Reenable the `WordPress.Security.NonceVerification.Missing` to reduce the chance of inadvertent CSRF errors in our code.

Additionally, `wp_verify_nonce()` is configured as an unslashing and sanitizing function. This it for developer ease due to the way nonce values are defined in WordPress and how the value is compared within the function.

The sniff was apparently disabled because it can be difficult to work with. There are two approaches I've found that enforce the sniff quite reliably.

**In instances the csrf token (nonce) is required**

```php
function my_csrf_suseptable_function() {
  if ( empty( $_GET['thenonce'] ) {
    return false;
  }

  if ( ! wp_verify_nonce( $_GET['thenonce'], 'my-action-name' ) ) {
    return false;
  }
  
  // current_user_can check followed by required functionality.
}
```

**In instnaces the csrf token (nonce) is not required**
```php
function my_function_expecting_a_query_string_param() {
   /*
    * This function does not require a nonce.
    * 
    * The query string parameters in this function are used without a nonce to modify
    * the output displayed to the user according to the page they are on. It does not
    * accept user input for recording in the database so a nonce check is not required.
    */
  // phpcs:disable WordPress.Security.NonceVerification.Missing

  // Do functionality requiring query string parameters

  // phpcs:enable

  // Do other functionality.
}
```
<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #38 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. In a project with these sniffs applied, write the function
   ```php
   function testing() {
      $input = isset( $_GET['input'] ) ? sanitize_text_field( wp_unslash( $_GET['input'] ) ) : '';
   }
   ```
2. Run `./vendor/bin/phpcs .`
3. On this branch phpcs should alert the developer to the lack of nonce in the function.



### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Security - Enabled the `WordPress.Security.NonceVerification.Missing` sniff.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @dkotter.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
