### PR TITLE
Bump testVersion to PHP 8.2

### DIFF
--- a/10up-Default/ruleset.xml
+++ b/10up-Default/ruleset.xml
@@ -112,5 +112,5 @@
 	<rule ref="PHPCompatibilityWP" />
 
 	<!-- PHP version check. -->
-	<config name="testVersion" value="8.1-"/>
+	<config name="testVersion" value="8.2-"/>
 </ruleset>


### PR DESCRIPTION
We should bump the test version to 8.2 to stay in line with [PHP LTS supported versions](https://www.php.net/supported-versions.php) and to keep our CI command clean and simple to understand. The alternative is to change the PHP at run time like this: phpcs . --runtime-set testVersion 8.2-.

Closes https://github.com/10up/phpcs-composer/issues/45

# Changelog Entry
Changed - Bump PHP test version to 8.2

# Credits
@claytoncollie

# Checklist:
 I agree to follow this project's [Code of Conduct](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
 I have updated the documentation accordingly.
 I have added tests to cover my change.
 All new and existing tests pass.

# Upgrade Path
For projects using this repository with a composer.json file, you should be referencing the dev-master branch like so, "10up/phpcs-composer": "dev-master" which means to get the latest version, you need to delete your composer.lock file and then re-install your dependencies with composer install

Once you have the latest version of this repository pulled in, make sure to remove the testVersion flag in your terminal command. Meaning that if you have phpcs . --runtime-set testVersion 8.1-, the command can now be simplified to phpcs .. You should now be linting against PHP version 8.2 and below.