### PR TITLE
Fix install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Install the library via Composer:
 
 ```bash
-$ composer require --dev 10up/phpcs-composer:"~3"
+$ composer require --dev 10up/phpcs-composer:"^3.0"
 ```
 
 That's it!


### PR DESCRIPTION
Updates the install docs to use `^` over `~`. Closes #50 